### PR TITLE
fix one micron URL

### DIFF
--- a/maps-and-models.html
+++ b/maps-and-models.html
@@ -161,7 +161,9 @@
         <img src="images/news/20um.png" class="card-image-square" data-mh="card-image">
         <div class="tool-name" data-mh="title">Selected 1 micron scans of BigBrain histological sections</div>
         <div class="tool-description" data-mh="description">Explore microscopic features at cellular level. BigBrain sections at micron in-plane resolution, aligned to the 20µm 3D-reconstructed BigBrain.</div>
-        <a href="https://atlases.ebrains.eu/viewer/#/a:juelich:iav:atlas:v1.0.0:1/t:minds:core:referencespace:v1.0.0:a1655b99-82f1-420f-a3c2-fe80fd4c8588/p:juelich:iav:atlas:v1.0.0:4/@:0.0.0.-W000.._eCwg.2-FUe3._-s_W.2_evlu..7LIx..gIW~.10AwC.B1KK~..1LSm" target="_blank"><button class="float-right small-spacer">Open ebrains siibra explorer</button></a>
+        <!-- Selected 1 micron scans of BigBrain histological sections (v1.0), section 4844 (cell body staining) -->
+        <!-- for service links to other sections, see https://gin.g-node.org/FZJ-INM1-BDA/20230512-1um-service-links/src/master/output/out.json -->
+        <a href="https://atlases.ebrains.eu/viewer/#/a:juelich:iav:atlas:v1.0.0:1/t:minds:core:referencespace:v1.0.0:a1655b99-82f1-420f-a3c2-fe80fd4c8588/p:juelich:iav:atlas:v1.0.0:4/f:73c1fa55-d099-4854-8cda-c9a403c6080a--50bc28b7e84781cde01d357aa0b4875d/@:0.0.0.-W000.._eCwg.2-FUe3._-s_W.2_evlu..7eI0..0.0.0..1LSm" target="_blank"><button class="float-right small-spacer">Open ebrains siibra explorer</button></a>
         <a href="https://search.kg.ebrains.eu/instances/73c1fa55-d099-4854-8cda-c9a403c6080a" target="_blank"><button class="float-right">Download via ebrains</button></a>
       </div>
       <div class="namecard fullcard">


### PR DESCRIPTION
this PR replaces the URL to generic big brain link with one that loads selected 1um slices (currently, slice 4844). Since there were no text about how to access the one micron plugin, I did not add instructions on how to access other slices.

ping @SusanneWenzel if you have a better slice in mind, please let me know.