### PR TITLE
add anchor links class

### DIFF
--- a/js/references.js
+++ b/js/references.js
@@ -286,6 +286,7 @@ function convertGroupedRefToNode(groupedRef) {
 
     // create header-anchor
     const headerAnchor = document.createElement("a")
+    headerAnchor.classList.add("anchor", "ref-section-anchor")
     headerAnchor.id = `ref-section-${groupedRef.name}`
 
     // create header


### PR DESCRIPTION
add class to section anchor: `anchor` and `ref-section-anchor`

The former is by request. The latter is added, so that the header can be styled with css easily.