### PR TITLE
fix: flex grow reference body

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1897,6 +1897,7 @@ a.anchor {
 /* Tabs styles */
 #tabs {
   position: relative;
+  flex: 1 1 auto;
 }
 .tabs-list {
   position: relative;


### PR DESCRIPTION
should fix #286 

@3design it appears `#tabs` is used in multiple places in other pages. So far, I have not noticed any ill effects in other pages.